### PR TITLE
Project3/mmap

### DIFF
--- a/include/vm/file.h
+++ b/include/vm/file.h
@@ -7,6 +7,9 @@ struct page;
 enum vm_type;
 
 struct file_page {
+	struct file *file;
+	size_t length;
+	off_t offset;
 };
 
 void vm_file_init (void);

--- a/include/vm/vm.h
+++ b/include/vm/vm.h
@@ -52,9 +52,8 @@ struct page {
 	/* Your implementation */
 	// Project 3 - Supplemental Page Table
 	struct hash_elem hash_elem; /* Hash table element for SPT */
-	// 29Oct21 - Writable 
 	bool writable; // 'vm_try_handler' needs to find out if the page is writable or read-only
-
+	int page_cnt; // only for file-mapped pages
 
 	/* Per-type data are binded into the union.
 	 * Each function automatically detects the current union */
@@ -127,5 +126,8 @@ struct lazy_load_info{
 	size_t page_zero_bytes;
 	off_t offset;
 };
+
+// spt_remove_page without deleting the page from SPT
+void remove_page(struct page *page);
 
 #endif  /* VM_VM_H */

--- a/userprog/process.c
+++ b/userprog/process.c
@@ -483,6 +483,8 @@ void process_exit(void)
 
 	struct thread *cur = thread_current();
 
+	//process_cleanup(true); // destroy SPT - mmap-exit (child-mm-wrt) : SPT must be alive before file closes
+
 	// P2-4 Close all opened files
 	for (int i = 0; i < FDCOUNT_LIMIT; i++)
 	{
@@ -902,6 +904,9 @@ lazy_load_segment(struct page *page, void *aux)
 
 	memset(kva + page_read_bytes, 0, page_zero_bytes);
 	free(lazy_load_info);
+
+	file_seek(file, offset); // may read the file later - reset fileobj pos
+	
 	return true;
 }
 

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -129,7 +129,7 @@ void syscall_handler(struct intr_frame *f)
 		f->R.rax = dup2(f->R.rdi, f->R.rsi);
 		break;
 	case SYS_MMAP:
-		f->R.rax = mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.rcx, f->R.r8);
+		f->R.rax = mmap(f->R.rdi, f->R.rsi, f->R.rdx, f->R.r10, f->R.r8);
 		break;
 	case SYS_MUNMAP:
 		munmap(f->R.rdi);

--- a/userprog/syscall.c
+++ b/userprog/syscall.c
@@ -486,5 +486,5 @@ void *mmap (void *addr, size_t length, int writable, int fd, off_t offset){
 
 // Project 3-3 mmap
 void munmap (void *addr){
-
+	do_munmap(addr);
 }

--- a/vm/anon.c
+++ b/vm/anon.c
@@ -29,6 +29,9 @@ vm_anon_init (void) {
 /* Initialize the file mapping */
 bool
 anon_initializer (struct page *page, enum vm_type type, void *kva) {
+	struct uninit_page *uninit = &page->uninit;
+	memset(uninit, 0, sizeof(struct uninit_page));
+
 	/* Set up the handler */
 	page->operations = &anon_ops;
 

--- a/vm/file.c
+++ b/vm/file.c
@@ -46,10 +46,89 @@ file_backed_destroy (struct page *page) {
 	struct file_page *file_page UNUSED = &page->file;
 }
 
+// used in lazy allocation - from process.c
+// 나중에 struct file_page에 vm_initializer *init 같은거 만들어서 uninit의 init 함수 (lazy_load_segment) 넘겨주는 식으로 리팩토링
+static bool
+lazy_load_segment(struct page *page, void *aux)
+{
+	/* TODO: Load the segment from the file */
+	/* TODO: This called when the first page fault occurs on address VA. */
+	/* TODO: VA is available when calling this function. */
+	struct lazy_load_info * lazy_load_info = (struct lazy_load_info *)aux;
+	struct file * file = lazy_load_info->file;
+	size_t page_read_bytes = lazy_load_info->page_read_bytes;
+	size_t page_zero_bytes = lazy_load_info->page_zero_bytes;
+	off_t offset = lazy_load_info->offset;
+
+	file_seek(file, offset);
+
+	//vm_do_claim_page(page);
+	ASSERT (page->frame != NULL); 	//이 상황에서 page->frame이 제대로 설정돼있는가?
+	void * kva = page->frame->kva;
+	if (file_read(file, kva, page_read_bytes) != (int)page_read_bytes)
+	{
+		//palloc_free_page(page); // #ifdef DBG Q. 여기서 free해주는거 맞아?
+		free(lazy_load_info);
+		return false;
+	}
+
+	memset(kva + page_read_bytes, 0, page_zero_bytes);
+	free(lazy_load_info);
+	return true;
+}
+
 /* Do the mmap */
+// similar design with load_segment - map consecutive pages until length runs out
 void *
 do_mmap (void *addr, size_t length, int writable,
 		struct file *file, off_t offset) {
+
+	// ASSERT((read_bytes + zero_bytes) % PGSIZE == 0);
+	// ASSERT(ofs % PGSIZE == 0);
+
+
+	void *start_addr = addr; // return value or in case of fail - free from this addr
+	struct thread *t = thread_current();
+
+	// file_seek(file, offset); // change offset itself
+	
+	// allocate at least one page
+	// throw off data that sticks out 
+	do{
+		// Fail : pages mapped overlaps other existing pages
+		if(spt_find_page(&t->spt, addr) != NULL){
+			void *free_addr = start_addr; // get page from this user vaddr and destroy them
+			while(free_addr < addr){
+				// free allocated uninit page
+				struct page *page = spt_find_page(&t->spt, free_addr);
+				destroy(page); // uninit destroy - free aux
+				free(page->frame);
+				free(page);
+
+				free_addr += PGSIZE;
+			}
+			return NULL;
+		}
+
+		size_t page_read_bytes = length < PGSIZE ? length : PGSIZE;
+		size_t page_zero_bytes = PGSIZE - page_read_bytes;
+
+		// file info to load onto memory once fault occurs
+		struct lazy_load_info *lazy_load_info = malloc(sizeof(struct lazy_load_info));
+		lazy_load_info->file = file;
+		lazy_load_info->page_read_bytes = page_read_bytes;
+		lazy_load_info->page_zero_bytes = page_zero_bytes;
+		lazy_load_info->offset = offset;
+		void *aux = lazy_load_info;
+		if (!vm_alloc_page_with_initializer(VM_FILE, addr,
+											writable, lazy_load_segment, aux))
+
+		offset += page_read_bytes;
+		length -= page_read_bytes;
+		addr += PGSIZE;
+	}while(length > PGSIZE);
+
+	return start_addr;
 }
 
 /* Do the munmap */


### PR DESCRIPTION
12 fail

pass tests/userprog/args-none
pass tests/userprog/args-single
pass tests/userprog/args-multiple
pass tests/userprog/args-many
pass tests/userprog/args-dbl-space
pass tests/userprog/halt
pass tests/userprog/exit
pass tests/userprog/create-normal
pass tests/userprog/create-empty
pass tests/userprog/create-null
pass tests/userprog/create-bad-ptr
pass tests/userprog/create-long
pass tests/userprog/create-exists
pass tests/userprog/create-bound
pass tests/userprog/open-normal
pass tests/userprog/open-missing
pass tests/userprog/open-boundary
pass tests/userprog/open-empty
pass tests/userprog/open-null
pass tests/userprog/open-bad-ptr
pass tests/userprog/open-twice
pass tests/userprog/close-normal
pass tests/userprog/close-twice
pass tests/userprog/close-bad-fd
pass tests/userprog/read-normal
pass tests/userprog/read-bad-ptr
pass tests/userprog/read-boundary
pass tests/userprog/read-zero
pass tests/userprog/read-stdout
pass tests/userprog/read-bad-fd
pass tests/userprog/write-normal
pass tests/userprog/write-bad-ptr
pass tests/userprog/write-boundary
pass tests/userprog/write-zero
pass tests/userprog/write-stdin
pass tests/userprog/write-bad-fd
pass tests/userprog/fork-once
pass tests/userprog/fork-multiple
pass tests/userprog/fork-recursive
pass tests/userprog/fork-read
pass tests/userprog/fork-close
pass tests/userprog/fork-boundary
pass tests/userprog/exec-once
pass tests/userprog/exec-arg
pass tests/userprog/exec-boundary
pass tests/userprog/exec-missing
pass tests/userprog/exec-bad-ptr
pass tests/userprog/exec-read
pass tests/userprog/wait-simple
pass tests/userprog/wait-twice
pass tests/userprog/wait-killed
pass tests/userprog/wait-bad-pid
pass tests/userprog/multi-recurse
pass tests/userprog/multi-child-fd
pass tests/userprog/rox-simple
pass tests/userprog/rox-child
pass tests/userprog/rox-multichild
pass tests/userprog/bad-read
pass tests/userprog/bad-write
pass tests/userprog/bad-read2
pass tests/userprog/bad-write2
pass tests/userprog/bad-jump
pass tests/userprog/bad-jump2
pass tests/vm/pt-grow-stack
pass tests/vm/pt-grow-bad
pass tests/vm/pt-big-stk-obj
pass tests/vm/pt-bad-addr
pass tests/vm/pt-bad-read
pass tests/vm/pt-write-code
FAIL tests/vm/pt-write-code2
pass tests/vm/pt-grow-stk-sc
pass tests/vm/page-linear
pass tests/vm/page-parallel
FAIL tests/vm/page-merge-seq
FAIL tests/vm/page-merge-par
FAIL tests/vm/page-merge-stk
FAIL tests/vm/page-merge-mm
pass tests/vm/page-shuffle
pass tests/vm/mmap-read
pass tests/vm/mmap-close
pass tests/vm/mmap-unmap
pass tests/vm/mmap-overlap
pass tests/vm/mmap-twice
pass tests/vm/mmap-write
pass tests/vm/mmap-ro
pass tests/vm/mmap-exit
pass tests/vm/mmap-shuffle
pass tests/vm/mmap-bad-fd
pass tests/vm/mmap-clean
FAIL tests/vm/mmap-inherit
pass tests/vm/mmap-misalign
pass tests/vm/mmap-null
pass tests/vm/mmap-over-code
pass tests/vm/mmap-over-data
pass tests/vm/mmap-over-stk
pass tests/vm/mmap-remove
pass tests/vm/mmap-zero
pass tests/vm/mmap-bad-fd2
pass tests/vm/mmap-bad-fd3
pass tests/vm/mmap-zero-len
pass tests/vm/mmap-off
FAIL tests/vm/mmap-bad-off
FAIL tests/vm/mmap-kernel
pass tests/vm/lazy-file
pass tests/vm/lazy-anon
FAIL tests/vm/swap-file
FAIL tests/vm/swap-anon
FAIL tests/vm/swap-iter
pass tests/vm/swap-fork
pass tests/filesys/base/lg-create
pass tests/filesys/base/lg-full
pass tests/filesys/base/lg-random
pass tests/filesys/base/lg-seq-block
pass tests/filesys/base/lg-seq-random
pass tests/filesys/base/sm-create
pass tests/filesys/base/sm-full
pass tests/filesys/base/sm-random
pass tests/filesys/base/sm-seq-block
pass tests/filesys/base/sm-seq-random
pass tests/filesys/base/syn-read
pass tests/filesys/base/syn-remove
pass tests/filesys/base/syn-write
pass tests/threads/alarm-single
pass tests/threads/alarm-multiple
pass tests/threads/alarm-simultaneous
pass tests/threads/alarm-priority
pass tests/threads/alarm-zero
pass tests/threads/alarm-negative
pass tests/threads/priority-change
pass tests/threads/priority-donate-one
pass tests/threads/priority-donate-multiple
pass tests/threads/priority-donate-multiple2
pass tests/threads/priority-donate-nest
pass tests/threads/priority-donate-sema
pass tests/threads/priority-donate-lower
pass tests/threads/priority-fifo
pass tests/threads/priority-preempt
pass tests/threads/priority-sema
pass tests/threads/priority-condvar
pass tests/threads/priority-donate-chain
FAIL tests/vm/cow/cow-simple
12 of 141 tests failed.
../../tests/Make.tests:28: recipe for target 'check' failed
